### PR TITLE
Improve stability

### DIFF
--- a/components/seeed_mr60bha2/seeed_mr60bha2.cpp
+++ b/components/seeed_mr60bha2/seeed_mr60bha2.cpp
@@ -140,6 +140,9 @@ void MR60BHA2Component::process_frame_(uint16_t frame_id, uint16_t frame_type, c
         if (current_breath_rate_int != 0) {
           float breath_rate_float;
           memcpy(&breath_rate_float, &current_breath_rate_int, sizeof(float));
+          if (this->breath_rate_sensor_->state == breath_rate_float) {
+            break;
+          }
           this->breath_rate_sensor_->publish_state(breath_rate_float);
         }
       }
@@ -147,18 +150,21 @@ void MR60BHA2Component::process_frame_(uint16_t frame_id, uint16_t frame_type, c
     case PEOPLE_EXIST_TYPE_BUFFER:
       if (this->people_exist_binary_sensor_ != nullptr && length >= 2) {
         uint16_t people_exist_int = encode_uint16(data[1], data[0]);
+        if (this->people_exist_binary_sensor_->state == people_exist_int) {
+          break;
+        }
         this->people_exist_binary_sensor_->publish_state(people_exist_int);
         if (people_exist_int == 0) {
-          if (this->breath_rate_sensor_ != nullptr) {
+          if (this->breath_rate_sensor_ != nullptr && this->breath_rate_sensor_->state != 0.0) {
             this->breath_rate_sensor_->publish_state(0.0);
           }
-          if (this->heart_rate_sensor_ != nullptr) {
+          if (this->heart_rate_sensor_ != nullptr && this->heart_rate_sensor_->state != 0.0) {
             this->heart_rate_sensor_->publish_state(0.0);
           }
-          if (this->distance_sensor_ != nullptr) {
+          if (this->distance_sensor_ != nullptr && this->distance_sensor_->state != 0.0) {
             this->distance_sensor_->publish_state(0.0);
           }
-          if (this->target_num_sensor_ != nullptr) {
+          if (this->target_num_sensor_ != nullptr && this->target_num_sensor_->state != 0) {
             this->target_num_sensor_->publish_state(0);
           }
         }
@@ -170,6 +176,9 @@ void MR60BHA2Component::process_frame_(uint16_t frame_id, uint16_t frame_type, c
         if (current_heart_rate_int != 0) {
           float heart_rate_float;
           memcpy(&heart_rate_float, &current_heart_rate_int, sizeof(float));
+          if (this->heart_rate_sensor_->state == heart_rate_float) {
+            break;
+          }
           this->heart_rate_sensor_->publish_state(heart_rate_float);
         }
       }
@@ -180,6 +189,9 @@ void MR60BHA2Component::process_frame_(uint16_t frame_id, uint16_t frame_type, c
           uint32_t current_distance_int = encode_uint32(data[7], data[6], data[5], data[4]);
           float distance_float;
           memcpy(&distance_float, &current_distance_int, sizeof(float));
+          if (this->distance_sensor_->state == distance_float) {
+            break;
+          }
           this->distance_sensor_->publish_state(distance_float);
         }
       }
@@ -187,6 +199,9 @@ void MR60BHA2Component::process_frame_(uint16_t frame_id, uint16_t frame_type, c
     case PRINT_CLOUD_BUFFER:
       if (this->target_num_sensor_ != nullptr && length >= 4) {
         uint32_t current_target_num_int = encode_uint32(data[3], data[2], data[1], data[0]);
+        if (this->target_num_sensor_->state == current_target_num_int) {
+          break;
+        }
         this->target_num_sensor_->publish_state(current_target_num_int);
       }
       break;

--- a/components/seeed_mr60bha2/seeed_mr60bha2.cpp
+++ b/components/seeed_mr60bha2/seeed_mr60bha2.cpp
@@ -128,6 +128,11 @@ bool MR60BHA2Component::validate_message_() {
 }
 
 void MR60BHA2Component::process_frame_(uint16_t frame_id, uint16_t frame_type, const uint8_t *data, size_t length) {
+  if (this->people_exist_binary_sensor_ != nullptr && this->people_exist_binary_sensor_->state == false && frame_type != PEOPLE_EXIST_TYPE_BUFFER) {
+    // Do not process other frames while people exists sensor is still false
+    return;
+  }
+
   switch (frame_type) {
     case BREATH_RATE_TYPE_BUFFER:
       if (this->breath_rate_sensor_ != nullptr && length >= 4) {

--- a/components/seeed_mr60bha2/seeed_mr60bha2.cpp
+++ b/components/seeed_mr60bha2/seeed_mr60bha2.cpp
@@ -144,10 +144,18 @@ void MR60BHA2Component::process_frame_(uint16_t frame_id, uint16_t frame_type, c
         uint16_t people_exist_int = encode_uint16(data[1], data[0]);
         this->people_exist_binary_sensor_->publish_state(people_exist_int);
         if (people_exist_int == 0) {
-          this->breath_rate_sensor_->publish_state(0.0);
-          this->heart_rate_sensor_->publish_state(0.0);
-          this->distance_sensor_->publish_state(0.0);
-          this->target_num_sensor_->publish_state(0);
+          if (this->breath_rate_sensor_ != nullptr) {
+            this->breath_rate_sensor_->publish_state(0.0);
+          }
+          if (this->heart_rate_sensor_ != nullptr) {
+            this->heart_rate_sensor_->publish_state(0.0);
+          }
+          if (this->distance_sensor_ != nullptr) {
+            this->distance_sensor_->publish_state(0.0);
+          }
+          if (this->target_num_sensor_ != nullptr) {
+            this->target_num_sensor_->publish_state(0);
+          }
         }
       }
       break;


### PR DESCRIPTION
This fixes a couple of things:

- Optimises memory usage: only allocate memory when actually used, and reuse the same memory when possible
- No longer crash when the binary sensor is enabled, but not all other sensors are
- No longer flood the ESP with unnecessary state changes when the state did not change at all
- When the binary sensor is enable and its state is false, do not handle any other frames until it has been set to true. This fixes my problem where the person count kept toggling between 0 and something else, from the log in [this comment](https://github.com/limengdu/MR60BHA2_ESPHome_external_components/issues/6#issuecomment-2614412318). While this is an issue with the mmWave module as it sends conflicting data, solving it here is easiest.

With these changes my module seems to be a lot more stable. I also lowered the I2C frequency to 10kHz, based on the [this comment](https://github.com/limengdu/MR60BHA2_ESPHome_external_components/issues/1#issuecomment-2541845781).
